### PR TITLE
Fix vector overflow bug

### DIFF
--- a/Core/Cyphers/BrianVector.cs
+++ b/Core/Cyphers/BrianVector.cs
@@ -99,7 +99,9 @@ public sealed class BrianVector
         var overflowUpper = Vector256.BitwiseAnd(
             inUpperRange,
             Vector256.GreaterThan(incremented, Z));
-        var overflowLower = Vector256.GreaterThan(incremented, z);
+        var overflowLower = Vector256.BitwiseAnd(
+            inLowerRange,
+            Vector256.GreaterThan(incremented, z));
         var overflow = Vector256.BitwiseOr(
             overflowUpper,
             overflowLower);
@@ -142,7 +144,9 @@ public sealed class BrianVector
         var overflowUpper = Vector128.BitwiseAnd(
             inUpperRange,
             Vector128.GreaterThan(incremented, Z));
-        var overflowLower = Vector128.GreaterThan(incremented, z);
+        var overflowLower = Vector128.BitwiseAnd(
+            inLowerRange,
+            Vector128.GreaterThan(incremented, z));
         var overflow = Vector128.BitwiseOr(
             overflowUpper,
             overflowLower);
@@ -185,7 +189,9 @@ public sealed class BrianVector
         var overflowUpper = Vector64.BitwiseAnd(
             inUpperRange,
             Vector64.GreaterThan(incremented, Z));
-        var overflowLower = Vector64.GreaterThan(incremented, z);
+        var overflowLower = Vector64.BitwiseAnd(
+            inLowerRange,
+            Vector64.GreaterThan(incremented, z));
         var overflow = Vector64.BitwiseOr(
             overflowUpper,
             overflowLower);

--- a/Core/Cyphers/DandyVector.cs
+++ b/Core/Cyphers/DandyVector.cs
@@ -70,7 +70,9 @@ public sealed class DandyVector
                 var overflowUpper = Vector128.BitwiseAnd(
                     inUpperRange,
                     Vector128.GreaterThan(incremented, Z));
-                var overflowLower = Vector128.GreaterThan(incremented, z);
+                var overflowLower = Vector128.BitwiseAnd(
+                    inLowerRange,
+                    Vector128.GreaterThan(incremented, z));
                 var overflow = Vector128.BitwiseOr(
                     overflowUpper,
                     overflowLower);
@@ -125,7 +127,9 @@ public sealed class DandyVector
                 var overflowUpper = Vector64.BitwiseAnd(
                     inUpperRange,
                     Vector64.GreaterThan(incremented, Z));
-                var overflowLower = Vector64.GreaterThan(incremented, z);
+                var overflowLower = Vector64.BitwiseAnd(
+                    inLowerRange,
+                    Vector64.GreaterThan(incremented, z));
                 var overflow = Vector64.BitwiseOr(
                     overflowUpper,
                     overflowLower);


### PR DESCRIPTION
The `applyShiftVector256` method in `DandyVector` was already patched, but these other spots weren't.